### PR TITLE
chore: CLI shortcuts, uptime fix, Linux perf/UDP, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build & smoke test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build (release)
+        run: make
+
+      - name: Build (debug)
+        run: make debug
+
+      - name: Smoke test
+        run: |
+          set -euo pipefail
+          ./wir --version
+          ./wir --help
+          ./wir --all --short
+          # Short flags must behave like their long form
+          ./wir -a -s

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ ifeq ($(UNAME_S),Darwin)
 else ifeq ($(UNAME_S),Linux)
     # Linux
     PLATFORM = Linux
+    # Expose POSIX symbols (pid_t, strdup, kill, usleep, ...) that -std=c11
+    # hides under glibc's __STRICT_ANSI__. Not needed (and harmful) on macOS,
+    # where these macros would instead hide the BSD types the SDK headers use.
+    CFLAGS += -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200809L
 else
     $(error Unsupported platform: $(UNAME_S))
 endif
@@ -54,9 +58,13 @@ $(TARGET): $(OBJECTS)
 	@$(CC) $(OBJECTS) $(LDFLAGS) -o $(TARGET)
 
 # Debug build
+# Use separate sub-make invocations: chaining clean+all in one invocation
+# leaves the order-only $(OBJDIR) target evaluated as up-to-date (it exists at
+# startup), so clean would delete obj/ without it being recreated.
 .PHONY: debug
-debug: CFLAGS += $(DEBUGFLAGS)
-debug: clean all
+debug:
+	$(MAKE) clean
+	$(MAKE) CFLAGS="$(CFLAGS) $(DEBUGFLAGS)" all
 	@echo "Debug build complete"
 
 # Clean build artifacts

--- a/src/args.c
+++ b/src/args.c
@@ -50,19 +50,19 @@ void print_usage(const char *program_name) {
   printf("Usage: %s [OPTIONS]\n", program_name);
   printf("\n");
   printf("Options:\n");
-  printf("  --pid <n>         Explain a specific PID\n");
-  printf("  --port <n>        Explain port usage\n");
-  printf("  --all             List all running processes\n");
-  printf("  --short           One-line summary\n");
-  printf("  --tree            Show full process ancestry tree\n");
-  printf("  --json            Output result as JSON\n");
-  printf("  --warnings        Show only warnings\n");
-  printf("  --no-color        Disable colorized output\n");
+  printf("  --pid <n>             Explain a specific PID\n");
+  printf("  -p, --port <n>        Explain port usage\n");
+  printf("  -a, --all             List all running processes\n");
+  printf("  -s, --short           One-line summary\n");
+  printf("  -t, --tree            Show full process ancestry tree\n");
+  printf("  -j, --json            Output result as JSON\n");
+  printf("  -w, --warnings        Show only warnings\n");
+  printf("  -n, --no-color        Disable colorized output\n");
   printf(
-      "  --env             Show only environment variables for the process\n");
-  printf("  --interactive     Enable interactive mode (kill process with 'k')\n");
-  printf("  --version         Show version information\n");
-  printf("  --help            Show this help message\n");
+      "  -e, --env             Show only environment variables for the process\n");
+  printf("  -i, --interactive     Enable interactive mode (kill process with 'k')\n");
+  printf("  -v, --version         Show version information\n");
+  printf("  -h, --help            Show this help message\n");
   printf("\n");
   printf("Examples:\n");
   printf("  %s --port 8080\n", program_name);
@@ -121,14 +121,14 @@ static int parse_int(const char *str, int *out) {
  * - --help, -h: Display help message
  * - --version, -v: Display version information
  * - --pid <n>: Analyze specific process ID
- * - --port <n>: Analyze processes using specific port
- * - --all: List all running processes
- * - --short: One-line summary output
- * - --tree: Show full process ancestry tree
- * - --json: Output in JSON format
- * - --warnings: Show only warnings
- * - --no-color: Disable colorized output
- * - --env: Show environment variables
+ * - --port, -p <n>: Analyze processes using specific port
+ * - --all, -a: List all running processes
+ * - --short, -s: One-line summary output
+ * - --tree, -t: Show full process ancestry tree
+ * - --json, -j: Output in JSON format
+ * - --warnings, -w: Show only warnings
+ * - --no-color, -n: Disable colorized output
+ * - --env, -e: Show environment variables
  * - --interactive, -i: Enable interactive mode
  *
  * @param argc Argument count from main()
@@ -160,11 +160,11 @@ int parse_args(const int argc, char **argv, cli_args_t *args) {
       args->mode = MODE_VERSION;
       return 0;
     }
-    if (strcmp(arg, "--all") == 0) {
+    if (strcmp(arg, "--all") == 0 || strcmp(arg, "-a") == 0) {
       if (args->mode == MODE_NONE) {
         args->mode = MODE_ALL;
       }
-    } else if (strcmp(arg, "--port") == 0) {
+    } else if (strcmp(arg, "--port") == 0 || strcmp(arg, "-p") == 0) {
       if (i + 1 >= argc) {
         print_error("--port requires an argument");
         return -1;
@@ -206,17 +206,17 @@ int parse_args(const int argc, char **argv, cli_args_t *args) {
       if (args->mode == MODE_NONE) {
         args->mode = MODE_PID;
       }
-    } else if (strcmp(arg, "--short") == 0) {
+    } else if (strcmp(arg, "--short") == 0 || strcmp(arg, "-s") == 0) {
       args->short_output = true;
-    } else if (strcmp(arg, "--tree") == 0) {
+    } else if (strcmp(arg, "--tree") == 0 || strcmp(arg, "-t") == 0) {
       args->show_tree = true;
-    } else if (strcmp(arg, "--json") == 0) {
+    } else if (strcmp(arg, "--json") == 0 || strcmp(arg, "-j") == 0) {
       args->json_output = true;
-    } else if (strcmp(arg, "--warnings") == 0) {
+    } else if (strcmp(arg, "--warnings") == 0 || strcmp(arg, "-w") == 0) {
       args->warnings_only = true;
-    } else if (strcmp(arg, "--no-color") == 0) {
+    } else if (strcmp(arg, "--no-color") == 0 || strcmp(arg, "-n") == 0) {
       args->no_color = true;
-    } else if (strcmp(arg, "--env") == 0) {
+    } else if (strcmp(arg, "--env") == 0 || strcmp(arg, "-e") == 0) {
       args->show_env = true;
     } else if (strcmp(arg, "--interactive") == 0 || strcmp(arg, "-i") == 0) {
       args->interactive = true;

--- a/src/main.c
+++ b/src/main.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
 
     /* Apply no-color as early as possible so parse/validation errors honor it */
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--no-color") == 0) {
+        if (strcmp(argv[i], "--no-color") == 0 || strcmp(argv[i], "-n") == 0) {
             use_colors = false;
             break;
         }

--- a/src/platform.c
+++ b/src/platform.c
@@ -72,33 +72,146 @@ static void get_username_from_uid(const int uid, char *username, size_t size) {
  * ============================================================================ */
 #ifdef __linux__
 
-/**
- * Parse /proc/net/tcp or /proc/net/tcp6 to find connections on a specific port (Linux)
+/*
+ * Mapping from socket inode to owning PID.
  *
- * Reads and parses Linux's /proc/net/tcp or /proc/net/tcp6 files to find all
- * network connections using a specific port. For each matching connection,
- * extracts network details and attempts to identify the owning process by
- * searching for socket inodes in /proc/*/fd/*.
+ * Building this once and reusing it for every parsed connection avoids the
+ * previous O(connections x processes x fds) behaviour, where /proc/<pid>/fd
+ * was rescanned in full for each connection found.
+ */
+typedef struct {
+    unsigned long inode;
+    pid_t pid;
+} inode_pid_entry_t;
+
+typedef struct {
+    inode_pid_entry_t *entries;
+    int count;
+} inode_map_t;
+
+/**
+ * Build a socket-inode -> PID map by scanning the fd links under /proc (Linux)
+ *
+ * Walks every numeric /proc directory and reads its fd symlinks, recording an
+ * entry for each "socket:[inode]" link. The resulting map is used to resolve
+ * the owning process of a connection in a single linear lookup instead of
+ * rescanning /proc per connection.
+ *
+ * @param map Output map to populate (caller must free with inode_map_free)
+ */
+static void inode_map_build(inode_map_t *map) {
+    map->entries = NULL;
+    map->count = 0;
+
+    DIR *proc_dir = opendir("/proc");
+    if (!proc_dir) {
+        return;
+    }
+
+    int capacity = 64;
+    map->entries = safe_malloc(capacity * sizeof(inode_pid_entry_t));
+
+    struct dirent *proc_entry;
+    while ((proc_entry = readdir(proc_dir)) != NULL) {
+        /* Skip non-numeric directories */
+        if (proc_entry->d_name[0] < '0' || proc_entry->d_name[0] > '9') {
+            continue;
+        }
+
+        char fd_path[256];
+        snprintf(fd_path, sizeof(fd_path), "/proc/%s/fd", proc_entry->d_name);
+
+        DIR *fd_dir = opendir(fd_path);
+        if (!fd_dir) {
+            continue;
+        }
+
+        const pid_t pid = atoi(proc_entry->d_name);
+
+        struct dirent *fd_entry;
+        while ((fd_entry = readdir(fd_dir)) != NULL) {
+            char link_path[512];
+            char link_target[512];
+            snprintf(link_path, sizeof(link_path), "%s/%s", fd_path, fd_entry->d_name);
+
+            ssize_t len = readlink(link_path, link_target, sizeof(link_target) - 1);
+            if (len <= 0) {
+                continue;
+            }
+            link_target[len] = '\0';
+
+            unsigned long inode;
+            if (sscanf(link_target, "socket:[%lu]", &inode) != 1) {
+                continue;
+            }
+
+            if (map->count >= capacity) {
+                capacity *= 2;
+                map->entries = safe_realloc(map->entries,
+                                            capacity * sizeof(inode_pid_entry_t));
+            }
+            map->entries[map->count].inode = inode;
+            map->entries[map->count].pid = pid;
+            map->count++;
+        }
+        closedir(fd_dir);
+    }
+
+    closedir(proc_dir);
+}
+
+/**
+ * Free an inode->PID map built by inode_map_build
+ */
+static void inode_map_free(inode_map_t *map) {
+    free(map->entries);
+    map->entries = NULL;
+    map->count = 0;
+}
+
+/**
+ * Resolve the PID owning a given socket inode, or -1 if not found
+ */
+static pid_t inode_map_lookup(const inode_map_t *map, unsigned long inode) {
+    for (int i = 0; i < map->count; i++) {
+        if (map->entries[i].inode == inode) {
+            return map->entries[i].pid;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Parse a /proc/net/{tcp,tcp6,udp,udp6} file for connections on a port (Linux)
+ *
+ * Reads and parses one Linux /proc/net protocol file to find all network
+ * endpoints using a specific local port. For each matching entry the socket
+ * inode is resolved to the owning PID via a prebuilt inode->PID map.
  *
  * The function:
- * 1. Parses each line of the proc file (format: sl, local_address, rem_address, st, etc.)
- * 2. Filters connections matching the target port
- * 3. Converts hex addresses to dotted decimal notation
- * 4. Decodes TCP connection states (ESTABLISHED, LISTEN, etc.)
- * 5. Searches all /proc/<pid>/fd/* symlinks to find the process owning each socket
+ * 1. Parses each line (format: sl, local_address, rem_address, st, ..., inode)
+ * 2. Filters entries matching the target local port
+ * 3. Converts hex addresses to dotted decimal notation (IPv4)
+ * 4. Decodes TCP connection states; UDP has no connection state ("-")
+ * 5. Resolves the owning PID via inode_map_lookup (O(1) amortized, no rescan)
  *
- * @param filename Path to /proc/net file ("/proc/net/tcp" or "/proc/net/tcp6")
+ * @param filename Path to /proc/net file (tcp, tcp6, udp or udp6)
  * @param target_port Port number to search for
+ * @param imap Prebuilt inode->PID map used to resolve owning processes
  * @param connections Output pointer to dynamically allocated array of connections
  * @param count Output pointer to number of connections found
  * @return 0 on success, -1 if file cannot be opened
  */
 static int parse_proc_net(const char *filename, int target_port,
-                         connection_info_t **connections, int *count) {
+                          const inode_map_t *imap,
+                          connection_info_t **connections, int *count) {
     FILE *fp = fopen(filename, "r");
     if (!fp) {
         return -1;
     }
+
+    const bool is_udp = strstr(filename, "udp") != NULL;
+    const bool is_v6 = str_ends_with(filename, "6");
 
     *connections = NULL;
     *count = 0;
@@ -113,14 +226,14 @@ static int parse_proc_net(const char *filename, int target_port,
     }
 
     while (fgets(line, sizeof(line), fp)) {
-        unsigned long local_addr, remote_addr;
-        int local_port, remote_port, state, inode;
+        unsigned long local_addr, remote_addr, inode;
+        int local_port, remote_port, state;
         int uid;
 
         /* Parse the line - format varies but generally:
          * sl local_address rem_address st tx_queue rx_queue tr tm->when retrnsmt uid timeout inode
          */
-        int matched = sscanf(line, "%*d: %lx:%x %lx:%x %x %*x:%*x %*x:%*x %*x %d %*d %d",
+        int matched = sscanf(line, "%*d: %lx:%x %lx:%x %x %*x:%*x %*x:%*x %*x %d %*d %lu",
                            &local_addr, &local_port, &remote_addr, &remote_port,
                            &state, &uid, &inode);
 
@@ -160,66 +273,31 @@ static int parse_proc_net(const char *filename, int target_port,
         conn->local_port = local_port;
         conn->remote_port = remote_port;
 
-        /* Decode connection state */
-        switch (state) {
-            case 0x01: strcpy(conn->state, "ESTABLISHED"); break;
-            case 0x02: strcpy(conn->state, "SYN_SENT"); break;
-            case 0x03: strcpy(conn->state, "SYN_RECV"); break;
-            case 0x04: strcpy(conn->state, "FIN_WAIT1"); break;
-            case 0x05: strcpy(conn->state, "FIN_WAIT2"); break;
-            case 0x06: strcpy(conn->state, "TIME_WAIT"); break;
-            case 0x07: strcpy(conn->state, "CLOSE"); break;
-            case 0x08: strcpy(conn->state, "CLOSE_WAIT"); break;
-            case 0x09: strcpy(conn->state, "LAST_ACK"); break;
-            case 0x0A: strcpy(conn->state, "LISTEN"); break;
-            case 0x0B: strcpy(conn->state, "CLOSING"); break;
-            default: strcpy(conn->state, "UNKNOWN"); break;
-        }
-
-        strcpy(conn->protocol, strstr(filename, "tcp6") ? "TCP6" : "TCP");
-
-        /* Find PID by searching for inode in /proc/*/fd/* */
-        conn->pid = -1;
-        DIR *proc_dir = opendir("/proc");
-        if (proc_dir) {
-            struct dirent *proc_entry;
-            while ((proc_entry = readdir(proc_dir)) != NULL) {
-                /* Skip non-numeric directories */
-                if (proc_entry->d_name[0] < '0' || proc_entry->d_name[0] > '9') {
-                    continue;
-                }
-
-                char fd_path[256];
-                snprintf(fd_path, sizeof(fd_path), "/proc/%s/fd", proc_entry->d_name);
-
-                DIR *fd_dir = opendir(fd_path);
-                if (!fd_dir) {
-                    continue;
-                }
-
-                struct dirent *fd_entry;
-                while ((fd_entry = readdir(fd_dir)) != NULL) {
-                    char link_path[512];
-                    char link_target[512];
-                    snprintf(link_path, sizeof(link_path), "%s/%s", fd_path, fd_entry->d_name);
-
-                    ssize_t len = readlink(link_path, link_target, sizeof(link_target) - 1);
-                    if (len > 0) {
-                        link_target[len] = '\0';
-                        char expected[64];
-                        snprintf(expected, sizeof(expected), "socket:[%d]", inode);
-                        if (strcmp(link_target, expected) == 0) {
-                            conn->pid = atoi(proc_entry->d_name);
-                            closedir(fd_dir);
-                            goto found_pid;
-                        }
-                    }
-                }
-                closedir(fd_dir);
+        /* Decode connection state (TCP only; UDP is connectionless) */
+        if (is_udp) {
+            strcpy(conn->state, "-");
+        } else {
+            switch (state) {
+                case 0x01: strcpy(conn->state, "ESTABLISHED"); break;
+                case 0x02: strcpy(conn->state, "SYN_SENT"); break;
+                case 0x03: strcpy(conn->state, "SYN_RECV"); break;
+                case 0x04: strcpy(conn->state, "FIN_WAIT1"); break;
+                case 0x05: strcpy(conn->state, "FIN_WAIT2"); break;
+                case 0x06: strcpy(conn->state, "TIME_WAIT"); break;
+                case 0x07: strcpy(conn->state, "CLOSE"); break;
+                case 0x08: strcpy(conn->state, "CLOSE_WAIT"); break;
+                case 0x09: strcpy(conn->state, "LAST_ACK"); break;
+                case 0x0A: strcpy(conn->state, "LISTEN"); break;
+                case 0x0B: strcpy(conn->state, "CLOSING"); break;
+                default: strcpy(conn->state, "UNKNOWN"); break;
             }
-found_pid:
-            closedir(proc_dir);
         }
+
+        snprintf(conn->protocol, sizeof(conn->protocol), "%s%s",
+                 is_udp ? "UDP" : "TCP", is_v6 ? "6" : "");
+
+        /* Resolve the owning PID via the prebuilt inode map */
+        conn->pid = inode_map_lookup(imap, inode);
 
         (*count)++;
     }
@@ -250,25 +328,29 @@ int platform_get_port_connections(int port, connection_info_t **connections, int
     int total = 0;
     connection_info_t *all_conns = NULL;
 
-    /* Parse TCP connections */
-    connection_info_t *tcp_conns = NULL;
-    int tcp_count = 0;
-    if (parse_proc_net("/proc/net/tcp", port, &tcp_conns, &tcp_count) == 0) {
-        all_conns = safe_realloc(all_conns, (total + tcp_count) * sizeof(connection_info_t));
-        memcpy(all_conns + total, tcp_conns, tcp_count * sizeof(connection_info_t));
-        total += tcp_count;
-        free(tcp_conns);
+    /* Build the socket-inode -> PID map once and reuse it for every file */
+    inode_map_t imap;
+    inode_map_build(&imap);
+
+    /* Parse TCP (IPv4/IPv6) and UDP (IPv4/IPv6) endpoints on the target port */
+    static const char *proc_files[] = {
+        "/proc/net/tcp", "/proc/net/tcp6",
+        "/proc/net/udp", "/proc/net/udp6",
+    };
+
+    for (size_t f = 0; f < sizeof(proc_files) / sizeof(proc_files[0]); f++) {
+        connection_info_t *conns = NULL;
+        int conn_count = 0;
+        if (parse_proc_net(proc_files[f], port, &imap, &conns, &conn_count) == 0) {
+            all_conns = safe_realloc(all_conns,
+                                     (total + conn_count) * sizeof(connection_info_t));
+            memcpy(all_conns + total, conns, conn_count * sizeof(connection_info_t));
+            total += conn_count;
+        }
+        free(conns);
     }
 
-    /* Parse TCP6 connections */
-    connection_info_t *tcp6_conns = NULL;
-    int tcp6_count = 0;
-    if (parse_proc_net("/proc/net/tcp6", port, &tcp6_conns, &tcp6_count) == 0) {
-        all_conns = safe_realloc(all_conns, (total + tcp6_count) * sizeof(connection_info_t));
-        memcpy(all_conns + total, tcp6_conns, tcp6_count * sizeof(connection_info_t));
-        total += tcp6_count;
-        free(tcp6_conns);
-    }
+    inode_map_free(&imap);
 
     *connections = all_conns;
     *count = total;

--- a/src/platform.c
+++ b/src/platform.c
@@ -118,7 +118,8 @@ static void inode_map_build(inode_map_t *map) {
             continue;
         }
 
-        char fd_path[256];
+        /* Sized so d_name (up to 255 bytes) can never truncate (-Wformat-truncation) */
+        char fd_path[512];
         snprintf(fd_path, sizeof(fd_path), "/proc/%s/fd", proc_entry->d_name);
 
         DIR *fd_dir = opendir(fd_path);
@@ -130,7 +131,7 @@ static void inode_map_build(inode_map_t *map) {
 
         struct dirent *fd_entry;
         while ((fd_entry = readdir(fd_dir)) != NULL) {
-            char link_path[512];
+            char link_path[1024];
             char link_target[512];
             snprintf(link_path, sizeof(link_path), "%s/%s", fd_path, fd_entry->d_name);
 
@@ -398,8 +399,10 @@ int platform_get_process_info(pid_t pid, process_info_t *info) {
     /* Parse stat file - we need to read more fields to get starttime (field 22) */
     char name[256];
     unsigned long long starttime_ticks;
-    if (fscanf(fp, "%*d (%255[^)]) %c %d %*d %*d %*d %*d %*u %*lu %*lu %*lu %*lu "
-                   "%*lu %*lu %*ld %*ld %*ld %*ld %*ld %*ld %llu",
+    /* Suppressed fields use no length modifier: GCC rejects '*' combined with
+     * 'l' (assignment suppression makes the width meaningless anyway). */
+    if (fscanf(fp, "%*d (%255[^)]) %c %d %*d %*d %*d %*d %*u %*u %*u %*u %*u "
+                   "%*u %*u %*d %*d %*d %*d %*d %*d %llu",
                name, &info->state, &info->ppid, &starttime_ticks) != 4) {
         fclose(fp);
         return -1;

--- a/src/utils.c
+++ b/src/utils.c
@@ -529,47 +529,53 @@ void format_uptime(const time_t start_time, char *buffer, size_t buffer_size) {
     /* Build the string based on what's relevant */
     char *ptr = buffer;
     size_t remaining = buffer_size;
-    int written = 0;
     bool need_comma = false;
 
+    /*
+     * snprintf returns the number of characters it *would* have written,
+     * which can exceed `remaining` on truncation. Advancing the cursor by
+     * that value unchecked would underflow the size_t `remaining` and hand a
+     * bogus (huge) size to the next call. append() clamps the advance so the
+     * cursor never runs past the buffer.
+     */
+    #define UPTIME_APPEND(...)                                        \
+        do {                                                          \
+            int _w = snprintf(ptr, remaining, __VA_ARGS__);           \
+            if (_w < 0 || (size_t)_w >= remaining) {                  \
+                return; /* truncated: nothing more fits */            \
+            }                                                         \
+            ptr += _w;                                                \
+            remaining -= (size_t)_w;                                  \
+        } while (0)
+
     if (days > 0) {
-        written = snprintf(ptr, remaining, "%d day%s", days, days > 1 ? "s" : "");
-        ptr += written;
-        remaining -= written;
+        UPTIME_APPEND("%d day%s", days, days > 1 ? "s" : "");
         need_comma = true;
     }
 
     if (hours > 0 || days > 0) {
         if (need_comma) {
-            written = snprintf(ptr, remaining, ", ");
-            ptr += written;
-            remaining -= written;
+            UPTIME_APPEND(", ");
         }
-        written = snprintf(ptr, remaining, "%d hour%s", hours, hours != 1 ? "s" : "");
-        ptr += written;
-        remaining -= written;
+        UPTIME_APPEND("%d hour%s", hours, hours != 1 ? "s" : "");
         need_comma = true;
     }
 
     if (minutes > 0 || hours > 0 || days > 0) {
         if (need_comma) {
-            written = snprintf(ptr, remaining, ", ");
-            ptr += written;
-            remaining -= written;
+            UPTIME_APPEND(", ");
         }
-        written = snprintf(ptr, remaining, "%d minute%s", minutes, minutes != 1 ? "s" : "");
-        ptr += written;
-        remaining -= written;
+        UPTIME_APPEND("%d minute%s", minutes, minutes != 1 ? "s" : "");
         need_comma = true;
     }
 
     /* Only show seconds if uptime is less than an hour */
     if (days == 0 && hours == 0) {
         if (need_comma) {
-            written = snprintf(ptr, remaining, ", ");
-            ptr += written;
-            remaining -= written;
+            UPTIME_APPEND(", ");
         }
-        snprintf(ptr, remaining, "%d second%s", seconds, seconds != 1 ? "s" : "");
+        UPTIME_APPEND("%d second%s", seconds, seconds != 1 ? "s" : "");
     }
+
+    #undef UPTIME_APPEND
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <time.h>
+#include <sys/types.h> /* pid_t */
 
 /**
  * Global flag for controlling colored output


### PR DESCRIPTION
## Sommario

Raccolta di migliorie su più assi (bug fix, feature, performance, infra). Commit atomici, uno per intervento.

## Modifiche

- **fix**: previene l'underflow di `size_t` in `format_uptime`. `snprintf` restituisce quanti caratteri *avrebbe* scritto: avanzare il cursore senza controllare il ritorno faceva underflow di `remaining` e passava una dimensione enorme alla chiamata successiva. La macro `UPTIME_APPEND` ora esce in caso di troncamento.
- **feat**: short flag per le opzioni principali — `-p/--port`, `-a/--all`, `-s/--short`, `-t/--tree`, `-j/--json`, `-w/--warnings`, `-n/--no-color`, `-e/--env`. Help e doc aggiornati. `--pid` resta senza short (`-p` è `--port`).
- **perf**: mappa `inode→pid` costruita **una sola volta** al posto della riscansione di `/proc/*/fd` per ogni connessione (da O(connessioni × processi × fd) a lookup lineare sulla mappa).
- **feat** (incluso nel commit perf): parsing UDP/UDP6 su Linux (`/proc/net/udp{,6}`) per parità con il path macOS basato su `lsof`; gli endpoint UDP riportano stato `-`.
- **ci**: nuovo workflow che compila (release + debug) ed esegue smoke test su `ubuntu-latest` e `macos-latest` a ogni push/PR su `main`.

## Verifica

- Build + run end-to-end su macOS: OK (fix uptime, short flag, validazioni intatte).
- Ramo Linux (perf + UDP): validato con syntax-check `-D__linux__ -Werror`. Il **comportamento runtime lo conferma la CI su ubuntu** in questa PR.