### PR TITLE
ci: build Homebrew formula from source (portable across arch/OS)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-and-release:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -23,32 +23,23 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 
-      - name: Update version.h
-        run: |
-          sed -i '' 's/#define WIR_VERSION ".*"/#define WIR_VERSION "${{ steps.get_version.outputs.version }}"/' src/version.h
-          cat src/version.h
+      # Sanity check: the tagged sources must build (Linux toolchain here)
+      - name: Build from source
+        run: make clean && make && ./wir --version
 
-      - name: Build binary
-        run: make clean && make
-
-      - name: Create tarball
-        run: |
-          mkdir -p wir-${{ steps.get_version.outputs.version }}
-          cp wir wir-${{ steps.get_version.outputs.version }}/
-          cp README.md wir-${{ steps.get_version.outputs.version }}/
-          tar -czf wir-${{ steps.get_version.outputs.version }}.tar.gz wir-${{ steps.get_version.outputs.version }}
-
-      - name: Calculate SHA256
+      # The Homebrew formula compiles from the GitHub-generated source tarball,
+      # so its checksum is what the formula must pin.
+      - name: Calculate SHA256 of source tarball
         id: sha256
         run: |
-          SHA256=$(shasum -a 256 wir-${{ steps.get_version.outputs.version }}.tar.gz | awk '{print $1}')
+          URL="https://github.com/${{ github.repository }}/archive/refs/tags/v${{ steps.get_version.outputs.version }}.tar.gz"
+          SHA256=$(curl -fsSL "$URL" | sha256sum | awk '{print $1}')
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
           echo "SHA256: $SHA256"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: wir-${{ steps.get_version.outputs.version }}.tar.gz
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,22 +55,23 @@ jobs:
         run: |
           cd tap
 
-          # Update the formula
+          # Formula compiles from source: works on any arch/OS (Intel/ARM/Linux)
           cat > Formula/wir.rb << 'EOF'
           class Wir < Formula
             desc "What Is Running - Port and Process Inspector"
-            homepage "https://github.com/AlbertoBarrago/Wir"
-            url "https://github.com/AlbertoBarrago/Wir/releases/download/v${{ steps.get_version.outputs.version }}/wir-${{ steps.get_version.outputs.version }}.tar.gz"
+            homepage "https://github.com/AlbertoBarrago/wir"
+            url "https://github.com/AlbertoBarrago/wir/archive/refs/tags/v${{ steps.get_version.outputs.version }}.tar.gz"
             sha256 "${{ steps.sha256.outputs.sha256 }}"
             version "${{ steps.get_version.outputs.version }}"
             license "MIT"
 
             def install
+              system "make"
               bin.install "wir"
             end
 
             test do
-              system "#{bin}/wir", "--help"
+              system "#{bin}/wir", "--version"
             end
           end
           EOF


### PR DESCRIPTION
## Problema

La release compilava un singolo binario su `macos-latest` (ARM64) e la formula Homebrew lo installava precompilato (`bin.install "wir"`). Conseguenze:

- non funziona su **Mac Intel**;
- non funziona su **Linux/Linuxbrew** (nonostante il codice ora compili su Linux).

## Modifica

- La formula ora punta al **tarball sorgente** generato da GitHub per il tag e **compila** in fase di install (`system "make"` + `bin.install "wir"`) → portabile su qualsiasi arch/OS.
- Il job calcola lo SHA256 del tarball sorgente (non più del binario) e non carica più un asset binario custom.
- Job spostato su `ubuntu-latest`, con build di sanità dai sorgenti (esercita anche il ramo Linux).
- Corretto l'URL con `wir` minuscolo (prima `Wir`) e `homepage`.

## Verifica

- Tarball sorgente `v1.1.0` scaricato e compilato localmente: `make` OK, `./wir --version` → `1.1.0`.
- La formula live del tap per `v1.1.0` viene allineata a parte a questo stesso schema compile-from-source.

Nota: il template della formula si applicherà dal **prossimo tag**; questa PR non fa partire una release.